### PR TITLE
Fix transit to be within 24h period post-requested time

### DIFF
--- a/lib/lunar.js
+++ b/lib/lunar.js
@@ -109,8 +109,17 @@ function hours_later(t, hrs) {
 
 function transit(t, lat, lon) {
   // Go 24h ahead and look backwards for the transit...
-  t = hours_later(t, 24);
-  return transit_direct(t, hour_angle_refined(t, lon));
+  const later_t = hours_later(t, 24);
+  let result = transit_direct(later_t, hour_angle_refined(later_t, lon));
+  if(result <= later_t) {
+    return result;
+  }
+  // If we've passed our max time though... just look near the beginning
+  result = transit_direct(t, hour_angle_refined(t, lon));
+  if(result >= t) {
+    return result;
+  }
+  return NaN;
 }
 
 function altitude(t, lat, lon) {

--- a/test/lunar.js
+++ b/test/lunar.js
@@ -33,10 +33,23 @@ describe("lunar", () => {
           lon: -74.01
       },
       {
-          // NYC ... and forward in that period so we get diff transit ...
+          // NYC ... and forward in that period so we get no transit ...
           t: astro.date_to_julian(new Date("2017-12-01T22:30:00-0500")),
           lat: 40.71,
           lon: -74.01
+      },
+      {
+          // NYC ... and forward in that period so we get next transit ...
+          t: astro.date_to_julian(new Date("2017-12-01T23:30:00-0500")),
+          lat: 40.71,
+          lon: -74.01
+      },
+      {
+          // Troy, NY .. but what's more important, right around the moon
+          // transit time!!
+          t: astro.date_to_julian(new Date("2016-01-01T05:00:00-0500")),
+          lat: 42.73,
+          lon: -73.68
       },
     ];
 
@@ -46,6 +59,8 @@ describe("lunar", () => {
     Date.parse("2016-03-14T11:04-0400"),
     Date.parse("2017-12-01T15:27-0500"),
     Date.parse("2017-12-02T16:10-0500"),
+    Date.parse("2017-12-02T16:10-0500"),
+    Date.parse("2016-01-02T00:04-0500"),
   ];
 
   const transits = [
@@ -53,7 +68,9 @@ describe("lunar", () => {
     Date.parse("2016-03-13T17:24-0400"),
     Date.parse("2016-03-13T17:24-0400"),
     Date.parse("2017-12-01T22:22-0500"),
+    NaN,
     Date.parse("2017-12-02T23:20-0500"),
+    Date.parse("2016-01-01T05:20-0500"),
   ];
 
   const sets = [
@@ -62,6 +79,8 @@ describe("lunar", () => {
     Date.parse("2016-03-14T00:31-0400"),
     Date.parse("2017-12-01T04:13-0500"),
     Date.parse("2017-12-02T05:26-0500"),
+    Date.parse("2017-12-02T05:26-0500"),
+    Date.parse("2016-01-01T11:26-0500"),
   ];
 
   function _check_calculation(input, result, lookup_function) {
@@ -70,9 +89,14 @@ describe("lunar", () => {
         input.lat * (Math.PI / 180),
         input.lon * (Math.PI / 180)
     );
-    expect(
-        astro.julian_to_date(calculation).getTime()
-    ).to.be.closeTo(result, 10 * 60 * 1000); // Allow error of 10min
+    const calculated_value = astro.julian_to_date(calculation).getTime();
+    if(isNaN(result)) {
+        expect(calculated_value).to.be.NaN; // jshint ignore:line
+    } else {
+        expect(
+            calculated_value
+        ).to.be.closeTo(result, 10 * 60 * 1000); // Allow error of 10min
+    }
   }
 
   it("should return the next moonrise to a given time", () => {


### PR DESCRIPTION
Sorry this took a bit because as it turns out - i too had a wrong test 😳 Dec 2nd 23:20 is not within the 24h period of Dec 1st 22:30... But now i also have a "no transit in this 24h period" test 🙂 