### PR TITLE
fix sin/cos azimuth

### DIFF
--- a/lib/solar.js
+++ b/lib/solar.js
@@ -201,9 +201,7 @@ class Location {
   }
 
   get azimuth() {
-    // NOTE: This Math.PI and negative silliness is so we return 0..2π
-    // (instead of -π..π).
-    return Math.PI + Math.atan2(-this.sin_azimuth, -this.cos_azimuth);
+    return Math.atan2(this.cos_azimuth, this.sin_azimuth) + Math.PI;
   }
 }
 
@@ -248,8 +246,8 @@ class Time {
       sin_hour_angle,
       cos_hour_angle,
       _sin_elevation(sin_lat, cos_lat, sin_dec, cos_dec, cos_hour_angle),
-      -sin_hour_angle,
-      -(cos_hour_angle * sin_lat - tan_dec * cos_lat)
+      cos_hour_angle * sin_lat - tan_dec * cos_lat,
+      sin_hour_angle
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Solar and lunar position calculations",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
Flip the signs and terms. This is because astro reports in clockwise from north (as it should!), but the internals should still be counterclockwise from east.